### PR TITLE
Add global configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ AR2DTO (ActiveRecord to DTO, pronounced R2-D2 or Artoo-Detoo) is a gem that lets
   - [Why AR2DTO?](#why-ar2dto)
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Global configuration](#global-configuration)
   - [Setting up your models](#setting-up-your-models)
   - [DTO class](#dto-class)
   - [#to_dto](#to_dto)
@@ -51,6 +52,35 @@ Or install it yourself as:
 
 In the following sections, we explain the API provided by the gem and some basic usage.
 
+Many aspects of AR2DTO are [configurable for individual models](#setting-up-your-models); typically this is achieved by passing options to the has_dto method within a given model. Some aspects of AR2DTO are [configured globally](#global-configuration) for all models.
+
+### Global Configuration
+Global configuration options affect all threads and models where has_dto has been defined. A common place to put these settings is in a Rails initializer file such as `config/initializers/ar2dto.rb`.
+These settings are assigned directly on the `AR2DTO.configure` object.
+
+Configuration options are:
+ - except
+
+Syntax examples:
+
+```ruby
+  # config/initializers/ar2dto.rb
+
+  AR2DTO.configure do |config|
+    config.except = [:updated_at]
+  end
+```
+
+OR
+
+```ruby
+  # config/initializers/ar2dto.rb
+
+  AR2DTO.configure.except = [:updated_at]
+```
+
+These options are intended to be set only once, during app initialization.
+
 ### Setting up your models
 
 To use the gem, you need to add `has_dto` to your ActiveRecord models. For example:
@@ -71,7 +101,7 @@ In addition to that, and optionally, you can have these objects be compliant wit
 ```ruby
 # config/initializers/ar2dto.rb
 
-AR2DTO.setup do |config|
+AR2DTO.configure do |config|
   config.active_model_compliance = true
 end
 ```

--- a/lib/ar2dto.rb
+++ b/lib/ar2dto.rb
@@ -2,14 +2,21 @@
 
 require "active_record"
 require "active_model"
+
 require_relative "ar2dto/active_model"
 require_relative "ar2dto/dto"
-require_relative "ar2dto/has_dto"
+require_relative "ar2dto/config"
 require_relative "ar2dto/version"
+require_relative "ar2dto/has_dto"
 
 ActiveRecord::Base.include ::AR2DTO::HasDTO
 
 module AR2DTO
   class Error < StandardError; end
-  # Your code goes here...
+
+  def self.configure
+    @config ||= AR2DTO::Config.instance
+    yield @config if block_given?
+    @config
+  end
 end

--- a/lib/ar2dto/config.rb
+++ b/lib/ar2dto/config.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "singleton"
+
+module AR2DTO
+  class Config
+    include Singleton
+
+    def self.reset!
+      instance.except = []
+    end
+
+    attr_accessor :except
+
+    def initialize
+      @except = []
+    end
+  end
+end

--- a/spec/ar2dto/config_spec.rb
+++ b/spec/ar2dto/config_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe AR2DTO::Config do
+  describe "#reset!" do
+    subject { described_class.reset! }
+
+    context "when it has a prior configuration" do
+      before do
+        described_class.instance.except = [:updated_at]
+      end
+
+      it "resets the configuration" do
+        expect { subject }.to change {
+          described_class.instance.except
+        }.from([:updated_at]).to([])
+      end
+    end
+  end
+
+  describe "#instance" do
+    context "when configuring an known specification" do
+      it "stores the configuration in the class" do
+        described_class.instance.except = [:updated_at]
+
+        expect(described_class.instance.except).to eq([:updated_at])
+      end
+    end
+
+    context "when configuring an unknown specification" do
+      it "raises a no method error" do
+        expect do
+          described_class.instance.unknown_specification = [:updated_at]
+        end.to raise_error(NoMethodError)
+      end
+    end
+  end
+end

--- a/spec/configure_spec.rb
+++ b/spec/configure_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe "AR2DTO.configure" do
+  context "when setting except" do
+    it "stores the configuration" do
+      AR2DTO.configure do |config|
+        config.except = [:updated_at]
+      end
+
+      expect(AR2DTO.configure.except).to eq([:updated_at])
+    end
+  end
+
+  context "when setting invalid configuration params" do
+    it "raises an undefined method error" do
+      expect do
+        AR2DTO.configure do |config|
+          config.invalid_configuration = [:invalid]
+        end
+      end.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,8 @@ require "support/fixtures/person"
 require "support/fixtures/shop/order"
 require "support/fixtures/user"
 
+require_relative "support/models/user"
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
@@ -24,6 +26,11 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  # Prevent configuration of being shared through examples
+  config.before :each do
+    AR2DTO::Config.reset! if Object.const_defined?("AR2DTO::Config")
   end
 
   config.before(:suite) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,6 @@ require "support/fixtures/person"
 require "support/fixtures/shop/order"
 require "support/fixtures/user"
 
-require_relative "support/models/user"
-
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/support/models/user.rb
+++ b/spec/support/models/user.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class User < ActiveRecord::Base
+  has_dto
+end

--- a/spec/support/models/user.rb
+++ b/spec/support/models/user.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class User < ActiveRecord::Base
-  has_dto
-end


### PR DESCRIPTION
In this PR we:
 - [x]  Added global configuration options to AR2DTO.
 - [ ] Added an example of global configuration: #default_excluded_attributes
   - [x] Added the option to the global configuration
   - [ ] Added the logic + tests to `#default_excluded_attributes`
 - [ ] Added a reset! method to the global configuration to be used around each spec
 