### PR TITLE
Fix boolean methods for DTOs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@
 
 .ruby-version
 
+.byebug_history
+
 Gemfile.lock

--- a/lib/ar2dto/dto.rb
+++ b/lib/ar2dto/dto.rb
@@ -18,17 +18,14 @@ module AR2DTO
     end
 
     def initialize(attributes = {})
-      singleton_class.instance_eval { attr_reader(*attributes.keys) }
-
-      attributes.each { |key, value| instance_variable_set("@#{key}", value) }
-
+      attributes.each { |key, value| define_singleton_method(key) { value } }
       super()
     end
 
     def ==(other)
       if other.instance_of?(self.class)
         attribute_names = self.class.original_model.attribute_names
-        as_json(only: attribute_names) == other.as_json(only: attribute_names)
+        attribute_names.all? { |name| send(name) == other.send(name) }
       else
         super
       end

--- a/spec/ar2dto/active_model_spec.rb
+++ b/spec/ar2dto/active_model_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "AR2DTO::ActiveModel" do
     {
       first_name: "Sandy",
       email: "sandy@example.com",
-      birthday: Time.new(1995, 8, 25)
+      birthday: Time.new(1995, 8, 25),
+      status: "pending"
     }
   end
 

--- a/spec/ar2dto/options_spec.rb
+++ b/spec/ar2dto/options_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "options" do
           has_dto
         end
 
-        expect(klass.new.to_dto).not_to respond_to(:updated_at)
+        expect(klass.new.to_dto).to_not respond_to(:updated_at)
       end
     end
   end

--- a/spec/ar2dto/record_to_dto/associations_spec.rb
+++ b/spec/ar2dto/record_to_dto/associations_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "#to_dto" do
         first_name: "Sandy",
         last_name: "Doe",
         email: "sandy@example.com",
-        birthday: Time.new(1995, 8, 25)
+        birthday: Time.new(1995, 8, 25),
+        status: "pending"
       }
     end
 

--- a/spec/ar2dto/record_to_dto/attributes_spec.rb
+++ b/spec/ar2dto/record_to_dto/attributes_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "#to_dto" do
         first_name: "Sandy",
         last_name: "Doe",
         email: "sandy@example.com",
-        birthday: Time.new(1995, 8, 25)
+        birthday: Time.new(1995, 8, 25),
+        status: "pending"
       }
     end
     let(:options) { {} }
@@ -20,7 +21,9 @@ RSpec.describe "#to_dto" do
       it { is_expected.to be_a(UserDTO) }
 
       it "doesn't expose ActiveRecord's methods" do
-        expect(subject).not_to respond_to(:update)
+        expect(subject).to_not respond_to(:update)
+        expect(subject).to_not respond_to(:pending?)
+        expect(subject).to_not respond_to(:confirmed?)
       end
 
       it "exposes methods to access the columns" do
@@ -46,7 +49,9 @@ RSpec.describe "#to_dto" do
       it { is_expected.to be_a(UserDTO) }
 
       it "doesn't expose ActiveRecord's methods" do
-        expect(subject).not_to respond_to(:update)
+        expect(subject).to_not respond_to(:update)
+        expect(subject).to_not respond_to(:pending?)
+        expect(subject).to_not respond_to(:confirmed?)
       end
 
       it "exposes methods to access the columns" do
@@ -59,6 +64,9 @@ RSpec.describe "#to_dto" do
           created_at: user.created_at,
           updated_at: user.updated_at
         )
+        expect(subject.id).to_not be_nil
+        expect(subject.created_at).to_not be_nil
+        expect(subject.updated_at).to_not be_nil
       end
 
       it "is not possible to set values from outside" do

--- a/spec/ar2dto/record_to_dto/equality_spec.rb
+++ b/spec/ar2dto/record_to_dto/equality_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "#to_dto" do
         first_name: "Sandy",
         last_name: "Doe",
         email: "sandy@example.com",
-        birthday: Time.new(1995, 8, 25)
+        birthday: Time.new(1995, 8, 25),
+        status: "pending"
       }
     end
     let(:options) { {} }
@@ -26,13 +27,13 @@ RSpec.describe "#to_dto" do
       it "is not equal to another DTO of another class with same attributes" do
         admin = double("Admin", attributes)
 
-        expect(subject).not_to eq(admin)
+        expect(subject).to_not eq(admin)
       end
 
       it "is not equal to another DTO of the same class with different attributes" do
         other_user = User.new(attributes.merge(first_name: "Kent")).to_dto
 
-        expect(subject).not_to eq(other_user)
+        expect(subject).to_not eq(other_user)
       end
 
       context "when including associations" do
@@ -59,13 +60,13 @@ RSpec.describe "#to_dto" do
       it "is not equal to another DTO of the same class with the same attributes that is persisted" do
         user_with_same_attributes = User.create!(attributes)
 
-        expect(subject).not_to eq(user_with_same_attributes.to_dto)
+        expect(subject).to_not eq(user_with_same_attributes.to_dto)
       end
 
       it "is not equal to another DTO of another class with same attributes" do
         admin = double("Admin", user.attributes)
 
-        expect(subject).not_to eq(admin)
+        expect(subject).to_not eq(admin)
       end
 
       context "when including associations" do

--- a/spec/ar2dto/record_to_dto/options_spec.rb
+++ b/spec/ar2dto/record_to_dto/options_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "#to_dto" do
         first_name: "Sandy",
         last_name: "Doe",
         email: "sandy@example.com",
-        birthday: Time.new(1995, 8, 25)
+        birthday: Time.new(1995, 8, 25),
+        status: "pending"
       }
     end
     let(:options) { {} }
@@ -28,6 +29,18 @@ RSpec.describe "#to_dto" do
 
         it "is not possible to call methods that weren't added" do
           expect(subject).to_not respond_to(:strange_name)
+          expect(subject).to_not respond_to(:superman?)
+        end
+
+        context "when including methods with question mark" do
+          let(:options) do
+            { methods: %i[full_name superman?] }
+          end
+
+          it "becomes accessible in the DTO" do
+            expect(subject.full_name).to eq("Sandy Doe")
+            expect(subject.superman?).to eq(false)
+          end
         end
       end
 
@@ -56,6 +69,15 @@ RSpec.describe "#to_dto" do
     end
 
     context "when active record is persisted" do
+      let(:attributes) do
+        {
+          first_name: "Clark",
+          last_name: "Kent",
+          email: "superman_hero@example.com",
+          birthday: Time.new(1995, 8, 25),
+          status: "pending"
+        }
+      end
       let(:user) { User.create!(attributes) }
 
       context "when including methods" do
@@ -64,11 +86,23 @@ RSpec.describe "#to_dto" do
         end
 
         it "becomes accessible in the DTO" do
-          expect(subject.full_name).to eq("Sandy Doe")
+          expect(subject.full_name).to eq("Clark Kent")
         end
 
         it "is not possible to call methods that weren't added" do
           expect(subject).to_not respond_to(:strange_name)
+          expect(subject).to_not respond_to(:superman?)
+        end
+
+        context "when including methods with question mark" do
+          let(:options) do
+            { methods: %i[full_name superman?] }
+          end
+
+          it "becomes accessible in the DTO" do
+            expect(subject.full_name).to eq("Clark Kent")
+            expect(subject.superman?).to eq(true)
+          end
         end
       end
 
@@ -79,7 +113,7 @@ RSpec.describe "#to_dto" do
 
         it "becomes inaccessible in the DTO" do
           expect(subject).to_not respond_to(:first_name)
-          expect(subject.last_name).to eq("Doe")
+          expect(subject.last_name).to eq("Kent")
         end
       end
 
@@ -90,7 +124,7 @@ RSpec.describe "#to_dto" do
 
         it "becomes inaccessible in the DTO" do
           expect(subject).to_not respond_to(:first_name)
-          expect(subject.last_name).to eq("Doe")
+          expect(subject.last_name).to eq("Kent")
         end
       end
     end

--- a/spec/ar2dto_spec.rb
+++ b/spec/ar2dto_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe AR2DTO do
   it "has a version number" do
-    expect(AR2DTO::VERSION).not_to be nil
+    expect(AR2DTO::VERSION).to_not be_nil
   end
 end

--- a/spec/support/fixtures/user.rb
+++ b/spec/support/fixtures/user.rb
@@ -4,6 +4,8 @@ class User < ActiveRecord::Base
   has_many :orders, class_name: "Shop::Order"
   has_one :person
 
+  enum status: { pending: 0, confirmed: 1 }
+
   has_dto
 
   def full_name
@@ -12,5 +14,9 @@ class User < ActiveRecord::Base
 
   def strange_name
     "Strange #{first_name}"
+  end
+
+  def superman?
+    full_name == "Clark Kent"
   end
 end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -8,6 +8,7 @@ ActiveRecord::Schema.define do
     t.string :last_name
     t.string :email, null: false
     t.datetime :birthday
+    t.integer :status, default: 0
 
     t.timestamps
   end


### PR DESCRIPTION
Make methods with question mark to work when transferred to DTOs.

Also added some explicit checks regarding `enum` columns from ActiveRecords, to make sure they work and that their auto generated methods from ActiveRecord are not transferred to DTOs.