### PR TITLE
Fix AR leakage

### DIFF
--- a/lib/ar2dto/converter.rb
+++ b/lib/ar2dto/converter.rb
@@ -10,8 +10,7 @@ module AR2DTO
     end
 
     def serializable_hash
-      hash = model.serializable_hash(options&.except(:methods, :include))
-      hash = add_methods(hash)
+      hash = model.serializable_hash(options&.except(:include)).as_json
       add_associations(hash)
     end
 
@@ -20,19 +19,6 @@ module AR2DTO
     def apply_configs(options)
       options[:except] = Array(model.class.ar2dto.except) | Array(options[:except])
       options
-    end
-
-    def add_methods(hash)
-      options&.dig(:methods)&.each do |method|
-        result = model.send(method)
-        result = if result.respond_to?(:to_dto)
-                   result.to_dto
-                 else
-                   result.as_json
-                 end
-        hash[method.to_s] = result
-      end
-      hash
     end
 
     def add_associations(hash)

--- a/spec/ar2dto/record_to_dto/attributes_spec.rb
+++ b/spec/ar2dto/record_to_dto/attributes_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe "#to_dto" do
       it "exposes methods to access the columns set by persistence" do
         expect(subject).to have_attributes(
           id: user.id,
-          created_at: user.created_at,
-          updated_at: user.updated_at
+          created_at: user.created_at.as_json,
+          updated_at: user.updated_at.as_json
         )
         expect(subject.id).to_not be_nil
         expect(subject.created_at).to_not be_nil

--- a/spec/ar2dto/record_to_dto/options_spec.rb
+++ b/spec/ar2dto/record_to_dto/options_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "#to_dto" do
             { methods: %i[myself] }
           end
 
-          it "becomes accessible in the DTO" do
+          it "gets converted into a hash" do
             expect(subject.myself).to be_a(Hash)
             expect(subject.myself["first_name"]).to eq("Sandy")
           end

--- a/spec/ar2dto/record_to_dto/options_spec.rb
+++ b/spec/ar2dto/record_to_dto/options_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe "#to_dto" do
             expect(subject.superman?).to eq(false)
           end
         end
+
+        context "when including methods that return an ActiveRecord object" do
+          let(:options) do
+            { methods: %i[myself] }
+          end
+
+          it "becomes accessible in the DTO" do
+            expect(subject.myself).to be_a(UserDTO)
+            expect(subject.myself.first_name).to eq("Sandy")
+          end
+        end
       end
 
       context "when excluding attributes via except" do

--- a/spec/ar2dto/record_to_dto/options_spec.rb
+++ b/spec/ar2dto/record_to_dto/options_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe "#to_dto" do
           end
 
           it "becomes accessible in the DTO" do
-            expect(subject.myself).to be_a(UserDTO)
-            expect(subject.myself.first_name).to eq("Sandy")
+            expect(subject.myself).to be_a(Hash)
+            expect(subject.myself["first_name"]).to eq("Sandy")
           end
         end
       end
@@ -74,7 +74,7 @@ RSpec.describe "#to_dto" do
         it "becomes inaccessible in the DTO" do
           expect(subject).to_not respond_to(:first_name)
           expect(subject.last_name).to eq("Doe")
-          expect(subject.birthday).to eq(Time.new(1995, 8, 25))
+          expect(subject.birthday).to eq(Time.new(1995, 8, 25).as_json)
         end
       end
     end

--- a/spec/ar2dto/relation_to_dto/options_spec.rb
+++ b/spec/ar2dto/relation_to_dto/options_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe ".to_dto" do
         expect(subject.first.full_name).to eq("Sandy Doe")
         expect(subject.second.full_name).to eq("Kent Simpson")
       end
+
+      context "when including methods that return an ActiveRecord object" do
+        let(:options) do
+          { methods: %i[myself] }
+        end
+
+        it "gets converted into a hash" do
+          expect(subject.first.myself["first_name"]).to eq("Sandy")
+          expect(subject.second.myself["first_name"]).to eq("Kent")
+        end
+      end
     end
 
     context "when excluding attributes via except" do

--- a/spec/support/fixtures/user.rb
+++ b/spec/support/fixtures/user.rb
@@ -19,4 +19,8 @@ class User < ActiveRecord::Base
   def superman?
     full_name == "Clark Kent"
   end
+
+  def myself
+    self
+  end
 end

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class User < ActiveRecord::Base
-  has_dto
-end


### PR DESCRIPTION
Not sure if we want to try to call `.to_dto` on the result of methods, or just call `.as_json` on everything as Rails does..