### PR TITLE
DTOs returned in methods are kept the same

### DIFF
--- a/lib/ar2dto/converter.rb
+++ b/lib/ar2dto/converter.rb
@@ -24,15 +24,19 @@ module AR2DTO
 
     def add_methods(hash)
       options&.dig(:methods)&.each do |method|
-        result = model.send(method)
-        result = if result.respond_to?(:to_dto)
-                   result.to_dto
-                 else
-                   result.as_json
-                 end
-        hash[method.to_s] = result
+        hash[method.to_s] = data_only(model.send(method))
       end
       hash
+    end
+
+    def data_only(object)
+      if object.respond_to?(:to_dto)
+        object.to_dto
+      elsif object.is_a?(::AR2DTO::DTO)
+        object
+      else
+        object.as_json
+      end
     end
 
     def add_associations(hash)

--- a/spec/ar2dto/record_to_dto/options_spec.rb
+++ b/spec/ar2dto/record_to_dto/options_spec.rb
@@ -73,6 +73,17 @@ RSpec.describe "#to_dto" do
             expect(subject.poro["created_at"]).to eq(user.created_at.as_json)
           end
         end
+
+        context "when including methods that return a DTO" do
+          let(:options) do
+            { methods: %i[dto] }
+          end
+
+          it "stays as a DTO" do
+            expect(subject.dto).to be_a(UserDTO)
+            expect(subject.dto.created_at.to_i).to eq(user.created_at.to_i)
+          end
+        end
       end
 
       context "when excluding attributes via except" do

--- a/spec/ar2dto/relation_to_dto/options_spec.rb
+++ b/spec/ar2dto/relation_to_dto/options_spec.rb
@@ -65,6 +65,19 @@ RSpec.describe ".to_dto" do
           expect(subject.second.poro["created_at"]).to eq(another_user.created_at.as_json)
         end
       end
+
+      context "when including methods that return a DTO" do
+        let(:options) do
+          { methods: %i[dto] }
+        end
+
+        it "stays as a DTO" do
+          expect(subject.first.dto).to be_a(UserDTO)
+          expect(subject.first.dto.created_at.to_i).to eq(user.created_at.to_i)
+          expect(subject.second.dto).to be_a(UserDTO)
+          expect(subject.second.dto.created_at.to_i).to eq(another_user.created_at.to_i)
+        end
+      end
     end
 
     context "when excluding attributes via except" do

--- a/spec/support/fixtures/user.rb
+++ b/spec/support/fixtures/user.rb
@@ -31,4 +31,8 @@ class User < ActiveRecord::Base
   def poro
     SimplePoro.new(created_at: created_at)
   end
+
+  def dto
+    to_dto
+  end
 end


### PR DESCRIPTION
Problem:
If a method returned a DTO, we were calling `to_dto` on it.

Possible solutions:
1. Don't call `#to_dto` on `AR2DTO::DTO` objects (implemented)
2. Make `#to_dto` return `self`

The bad thing about 2. is that if someone does `some_dto.to_dto(include: :some_association)` we can't do anything with that since `some_dto` has already the "calculated values". That's why I prefer 1.