### PR TITLE
Add ActiveSupport::TimeWithZone to Converter allowed types

### DIFF
--- a/lib/ar2dto/converter.rb
+++ b/lib/ar2dto/converter.rb
@@ -2,8 +2,11 @@
 
 module AR2DTO
   class Converter
-    ALLOWED_TYPES = [Symbol, BigDecimal, Regexp, IO, Range, Time, Date, DateTime,
-                     URI::Generic, Pathname, IPAddr, Process::Status, Exception].freeze
+    ALLOWED_TYPES = [
+      Symbol, BigDecimal, Regexp, IO, Range, Time, Date, DateTime,
+      URI::Generic, Pathname, IPAddr, Process::Status, Exception,
+      ActiveSupport::TimeWithZone
+    ].freeze
     attr_reader :model, :options
 
     def initialize(model, options)


### PR DESCRIPTION
At runtime `ActiveSupport::TimeWithZone` works exactly like `Time`, so it makes sense to allow it too. Without this change, methods which return an `ActiveSupport::TimeWithZone` will be added to the DTO as Strings because `Converter` calls `#as_json` on them.

```ruby
# == Schema Information
#
# Table name: shifts
#
#  id          :integer         not null, primary key
#  name        :string          not null
#  start_time  :datetime        not null
class Event < ActiveRecord::Base
  def gates_close_at
    start_time - 2.hours
  end
end


event_dto = Event.first.to_dto(methods: [:gates_close_at])
event_dto.start_time
# => Fri, 12 Dec 2025 20:00:00.000000000 GMT +00:00
event_dto.gates_close_at
# => "2025-12-12T18:00:00.000+00:00"
```